### PR TITLE
Explore babel options from ember-cli-babel

### DIFF
--- a/tests/ember-app/config/targets.js
+++ b/tests/ember-app/config/targets.js
@@ -3,7 +3,7 @@
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
-  'last 1 Safari versions',
+  // 'last 1 Safari versions',
 ];
 
 // Ember's browser support policy is changing, and IE11 support will end in

--- a/tests/ember-app/ember-cli-build.js
+++ b/tests/ember-app/ember-cli-build.js
@@ -5,6 +5,29 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
+    babel: {
+      // --> has good impact on build size
+      // --> has no impact on build size
+      // useBuiltIns: false, // default, no polyfill
+      // useBuiltIns: 'entry', // our browsertargets already include what would be polyfilled
+      // --> breaks the build
+      // useBuiltIns: 'usage',
+    },
+    'ember-cli-babel': {
+      // --> environment setup
+      throwUnlessParallelizable: true,
+      enableTypeScriptTransform: true,
+      // --> has good impact on build size
+      // --> has no impact on build size
+      disableEmberModulesAPIPolyfill: true,
+      disableEmberDataPackagesPolyfill: true,
+      disableDebugTooling: true,
+      includeExternalHelpers: false,
+      includePolyfill: false,
+      // --> breaks the build
+      // leaves the ESM, but still concatenates everything, which is then invalid ESM
+      // compileModules: false,
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Left to figure out

- [ ] How do we tell the build that our browser targets natively support class fields
- [ ] How do we tell the build that our browser targets natively support private fields