### PR TITLE
chore: rename package to ember-cli-esbuild-minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ monorepo for using ESBuild for minification in Ember.JS
 1. remove `ember-cli-terser` or `ember-cli-ugfily`
 2.
     ```
-    yarn add --dev @nullvoxpopuli/ember-cli-esbuild
+    yarn add --dev ember-cli-esbuild-minifier
     # or
-    npm install --save-dev @nullvoxpopuli/ember-cli-esbuild
+    npm install --save-dev ember-cli-esbuild-minifier
     ```
 
 

--- a/ember-cli-esbuild/README.md
+++ b/ember-cli-esbuild/README.md
@@ -1,8 +1,8 @@
 
-@nullvoxpopuli/ember-cli-esbuild
+ember-cli-esbuild-minifier
 ==============================================================================
 
-[![npm](https://img.shields.io/npm/v/@nullvoxpopuli/ember-cli-esbuild.svg)](https://www.npmjs.com/package/@nullvoxpopuli/ember-cli-esbuild)
+[![npm](https://img.shields.io/npm/v/ember-cli-esbuild-minifier.svg)](https://www.npmjs.com/package/ember-cli-esbuild-minifier)
 [![Build Status](https://github.com/nullvoxpopuli/ember-cli-esbuild/workflows/CI/badge.svg)](https://github.com/nullvoxpopuli/ember-cli-esbuild/actions?query=workflow%3ACI)
 
 [esbuild](https://esbuild.github.io) integration to

--- a/ember-cli-esbuild/package.json
+++ b/ember-cli-esbuild/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nullvoxpopuli/ember-cli-esbuild",
+  "name": "ember-cli-esbuild-minifier",
   "version": "4.2.9",
   "description": "JavaScript minification for Ember-CLI",
   "keywords": [

--- a/tests/ember-app/package.json
+++ b/tests/ember-app/package.json
@@ -28,7 +28,7 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@jest/globals": "^27.2.5",
-    "@nullvoxpopuli/ember-cli-esbuild": "*",
+    "ember-cli-esbuild-minifier": "*",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "del": "^6.0.0",


### PR DESCRIPTION
BREAKING CHANGE:
  @nullvoxpopuli/ember-cli-esbuild will no longer receive updates.
  Instead, insteall ember-cli-esbuild-minifier