### PR TITLE
build(core): Extract esbuild as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ monorepo for using ESBuild for minification in Ember.JS
 1. remove `ember-cli-terser` or `ember-cli-uglify`
 2.
     ```
-    yarn add --dev ember-cli-esbuild-minifier
+    yarn add --dev ember-cli-esbuild-minifier esbuild
     # or
-    npm install --save-dev ember-cli-esbuild-minifier
+    npm install --save-dev ember-cli-esbuild-minifier esbuild
     ```
 
 

--- a/ember-cli-esbuild/README.md
+++ b/ember-cli-esbuild/README.md
@@ -16,9 +16,9 @@ Installation
 1. remove `ember-cli-terser` or `ember-cli-ugfily`
 2.
     ```
-    yarn add --dev @nullvoxpopuli/ember-cli-esbuild
+    yarn add --dev @nullvoxpopuli/ember-cli-esbuild esbuild
     # or
-    npm install --save-dev @nullvoxpopuli/ember-cli-esbuild
+    npm install --save-dev @nullvoxpopuli/ember-cli-esbuild esbuild
     ```
 
 Usage

--- a/ember-cli-esbuild/package.json
+++ b/ember-cli-esbuild/package.json
@@ -26,7 +26,6 @@
     "async-promise-queue": "^1.0.5",
     "broccoli-plugin": "^4.0.7",
     "debug": "^4.3.4",
-    "esbuild": "^0.14.27",
     "lodash.defaultsdeep": "^4.6.1",
     "symlink-or-copy": "^1.3.1",
     "walk-sync": "^3.0.0",
@@ -36,7 +35,11 @@
     "@nullvoxpopuli/eslint-configs": "^2.2.5",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.1",
+    "esbuild": "^0.14.27",
     "semantic-release": "^17.4.7"
+  },
+  "peerDependencies": {
+    "esbuild": "^0"
   },
   "engines": {
     "node": ">= 12"


### PR DESCRIPTION
BREAKING CHANGE: esbuild should now be installed separately