### PR TITLE
fix: Fix taking default Ember CLI source map config into account

### DIFF
--- a/ember-cli-esbuild/index.js
+++ b/ember-cli-esbuild/index.js
@@ -10,8 +10,8 @@ module.exports = {
       enabled: app.env === 'production',
     };
 
-    if (app.options.sourcemaps && !areSourceMapsEnabled(app.options.sourcemaps)) {
-      defaultOptions.sourceMap = false;
+    if (app.options.sourcemaps && areSourceMapsEnabled(app.options.sourcemaps)) {
+      defaultOptions.sourceMap = 'linked';
     }
 
     let addonOptions = app.options['ember-cli-esbuild'];

--- a/ember-cli-esbuild/lib/broccoli/index.js
+++ b/ember-cli-esbuild/lib/broccoli/index.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const walkSync = require('walk-sync');
 const Plugin = require('broccoli-plugin');
-const defaults = require('lodash.defaultsdeep');
 const symlinkOrCopy = require('symlink-or-copy');
 const MatcherCollection = require('matcher-collection');
 const debug = require('debug')('ember-cli-esbuild');
@@ -33,11 +32,7 @@ module.exports = class ESBuildWriter extends Plugin {
       needsCache: false,
     });
 
-    this.options = defaults(options, {
-      esbuild: {
-        sourceMap: {},
-      },
-    });
+    this.options = options;
 
     this.concurrency =
       Number(process.env.JOBS) ||

--- a/tests/ember-app/ember-cli-build.js
+++ b/tests/ember-app/ember-cli-build.js
@@ -2,17 +2,22 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-const { SOURCEMAP, DISABLE_MINIFY } = process.env;
+const { SOURCEMAP, ESBUILD_SOURCEMAP, DISABLE_MINIFY } = process.env;
 
 module.exports = function (defaults) {
   let options = {
     'ember-cli-esbuild': {
       enabled: !DISABLE_MINIFY,
     },
+    sourcemaps: {},
   };
 
   if (SOURCEMAP) {
-    options['ember-cli-esbuild'].sourceMap = SOURCEMAP;
+    options.sourcemaps.enabled = true;
+  }
+
+  if (ESBUILD_SOURCEMAP) {
+    options['ember-cli-esbuild'].sourceMap = ESBUILD_SOURCEMAP;
   }
 
   let app = new EmberApp(defaults, {

--- a/tests/ember-app/node-tests/build.test.mjs
+++ b/tests/ember-app/node-tests/build.test.mjs
@@ -102,22 +102,36 @@ test('basic build', async () => {
   expect(vendor).not.toMatch(/unsplash\.jpg/);
 });
 
+test('build: source map enabled through Ember CLI config', async () => {
+  await build({ SOURCEMAP: 'true' });
+
+  expect(exists('dist/**/*.map')).toBeTruthy();
+  expect(await hasJSSourceMapsURL(true)).toBeTruthy();
+});
+
+test('build: sourceMap: linked', async () => {
+  await build({ ESBUILD_SOURCEMAP: 'linked' });
+
+  expect(exists('dist/**/*.map')).toBeTruthy();
+  expect(await hasJSSourceMapsURL(true)).toBeTruthy();
+});
+
 test('build: sourceMap: external', async () => {
-  await build({ SOURCEMAP: 'external' });
+  await build({ ESBUILD_SOURCEMAP: 'external' });
 
   expect(exists('dist/**/*.map')).toBeTruthy();
   expect(await hasJSSourceMapsURL(false)).toBeFalsy();
 });
 
 test('build: sourceMap: both', async () => {
-  await build({ SOURCEMAP: 'both' });
+  await build({ ESBUILD_SOURCEMAP: 'both' });
 
   expect(exists('dist/**/*.map')).toBeTruthy();
   expect(await hasJSSourceMapsURL(true)).toBeTruthy();
 });
 
 test('build: sourceMap: inline', async () => {
-  await build({ SOURCEMAP: 'inline' });
+  await build({ ESBUILD_SOURCEMAP: 'inline' });
 
   expect(exists('dist/**/*.map')).toBeFalsy();
   expect(await hasJSSourceMapsURL(true)).toBeTruthy();


### PR DESCRIPTION
An explicit `sourcemaps: { enabled: true }` config in `ember-cli-build.js` was not taken into account correctly. On a production build (where the default config would be to have source maps disabled) with this setting, the addon would still pass an empty `sourceMap` config for esbuild, leading to no source maps by default.