### PR TITLE
enhancement: allow passing in `target` as an option to esbuild

### DIFF
--- a/ember-cli-esbuild/README.md
+++ b/ember-cli-esbuild/README.md
@@ -52,7 +52,7 @@ var app = new EmberApp({
 
 - `sourceMap`: the ESBuild sourcemap option. `false`, by default. Can be: `'linked'`, `'external'`, `'inline'`, `'both'`, or `false`. See [ESBuild's docs](https://esbuild.github.io/api/#sourcemap) for more info
 
-- `target?: string | string[]`: the ESBuild target option. `esnext` by default. See [ESBuild's docs](https://esbuild.github.io/api/#target) for more info on the available targets.
+- `target?: string | string[]`: the ESBuild target option. See [ESBuild's docs](https://esbuild.github.io/api/#target) for more info on the available targets.
 
 ### Source Maps
 

--- a/ember-cli-esbuild/README.md
+++ b/ember-cli-esbuild/README.md
@@ -52,6 +52,8 @@ var app = new EmberApp({
 
 - `sourceMap`: the ESBuild sourcemap option. `false`, by default. Can be: `'linked'`, `'external'`, `'inline'`, `'both'`, or `false`. See [ESBuild's docs](https://esbuild.github.io/api/#sourcemap) for more info
 
+- `target?: string | string[]`: the ESBuild target option. `esnext` by default. See [ESBuild's docs](https://esbuild.github.io/api/#target) for more info on the available targets.
+
 ### Source Maps
 
 Source maps are disabled by default for production builds in Ember CLI. If you

--- a/ember-cli-esbuild/lib/broccoli/process-file.js
+++ b/ember-cli-esbuild/lib/broccoli/process-file.js
@@ -25,6 +25,7 @@ module.exports = async function processFile(
     await esbuild.build({
       entryPoints: [inFile],
       sourcemap: options.sourceMap || false,
+      target: options.target,
       // bundling happens externally (broccoli, webpack, etc)
       bundle: false,
       minify: true,


### PR DESCRIPTION
Allow passing in the target to esbuild